### PR TITLE
Fixing the KindOfStaticString error in HHVM 3.12.0

### DIFF
--- a/msgpack-variant.h
+++ b/msgpack-variant.h
@@ -24,6 +24,12 @@
 
 #include <msgpack.hpp>
 
+# if HHVM_VERSION_ID < 31201
+# define KindOfStaticString KindOfStaticString
+# else
+# define KindOfStaticString KindOfPersistentString
+#endif
+
 using namespace HPHP;
 
 namespace msgpack {


### PR DESCRIPTION
With HHVM 3.12.0 i can't build the current version og msgpack-hhvm because the error:

`msgpack-variant.h:126:10: error: ‘KindOfStaticString’ was not declared in this scope case KindOfStaticString:`
# facebook/hhvm@127a039

The Travis is failing because its running agains't 3.6.6
